### PR TITLE
Highmates sent from empire will no longer break the roof

### DIFF
--- a/1.5/Source/Harmony/Pawn_RoyaltyTracker_OnPostTitleChanged.cs
+++ b/1.5/Source/Harmony/Pawn_RoyaltyTracker_OnPostTitleChanged.cs
@@ -21,11 +21,26 @@ namespace VanillaRacesExpandedHighmate
                 && faction == Faction.OfEmpire)
             {
 
-                var letter = LetterMaker.MakeLetter("VRE_AwardedHighmate".Translate(), "VRE_AwardedHighmateDesc".Translate(__instance.pawn.LabelCap), LetterDefOf.PositiveEvent);
-                Find.LetterStack.ReceiveLetter(letter);
-                PawnGenerationRequest request = new PawnGenerationRequest(Faction.OfPlayer.def.basicMemberKind, Faction.OfPlayer, PawnGenerationContext.NonPlayer, -1, forceGenerateNewPawn: true, allowDead: false, allowDowned: false, canGeneratePawnRelations: false, false, 20f, forceAddFreeWarmLayerIfNeeded: false, allowGay: true, allowPregnant: false, allowFood: true, allowAddictions: true, inhabitant: false, certainlyBeenInCryptosleep: false, forceRedressWorldPawnIfFormerColonist: false, worldPawnFactionDoesntMatter: false, 0f, 0f, null, 1f, null, null, null, null, null, null, null, null, null, null, null, null, forceNoIdeo: false, forceNoBackstory: false, forbidAnyTitle: false, forceDead: false, null, null, InternalDefOf.Highmate, null, null, 0f, DevelopmentalStage.Adult, null, null);
-                Pawn pawn = PawnGenerator.GeneratePawn(request);
-                DropPodUtility.DropThingsNear(__instance.pawn.Position, __instance.pawn.Map, new List<Thing>() { pawn }, 110, false, false, false, false);
+                IntVec3 position;
+                if (!DropCellFinder.TryFindDropSpotNear(__instance.pawn.Position, __instance.pawn.Map, out position, false, false, false))
+                {
+                    // If we can't find a safe cell near the target pawn then use trade drop spot
+                    // instead of relying on a completely random position. A random position may
+                    // attempt to break through roof, and if it's overhead mountain - cause the
+                    // roof to collapse and drop pod to be destroyed.
+                    position = DropCellFinder.TradeDropSpot(__instance.pawn.Map);
+                }
+
+                // Make sure the generated position is valid to prevent the letter from appearing
+                // without actually spawning the highmate on the map.
+                if (position.IsValid)
+                {
+                    var letter = LetterMaker.MakeLetter("VRE_AwardedHighmate".Translate(), "VRE_AwardedHighmateDesc".Translate(__instance.pawn.LabelCap), LetterDefOf.PositiveEvent);
+                    Find.LetterStack.ReceiveLetter(letter);
+                    PawnGenerationRequest request = new PawnGenerationRequest(Faction.OfPlayer.def.basicMemberKind, Faction.OfPlayer, PawnGenerationContext.NonPlayer, -1, forceGenerateNewPawn: true, allowDead: false, allowDowned: false, canGeneratePawnRelations: false, false, 20f, forceAddFreeWarmLayerIfNeeded: false, allowGay: true, allowPregnant: false, allowFood: true, allowAddictions: true, inhabitant: false, certainlyBeenInCryptosleep: false, forceRedressWorldPawnIfFormerColonist: false, worldPawnFactionDoesntMatter: false, 0f, 0f, null, 1f, null, null, null, null, null, null, null, null, null, null, null, null, forceNoIdeo: false, forceNoBackstory: false, forbidAnyTitle: false, forceDead: false, null, null, InternalDefOf.Highmate, null, null, 0f, DevelopmentalStage.Adult, null, null);
+                    Pawn pawn = PawnGenerator.GeneratePawn(request);
+                    DropPodUtility.DropThingsNear(position, __instance.pawn.Map, new List<Thing>() { pawn }, 110, false, false, false, false);
+                }
             }
         }
     }


### PR DESCRIPTION
I've slightly changed the code for highmates from empire to:
- Try find a spot near the royal pawn, if possible
- If that failed, try to find a trade drop spot
- If that failed as well because (the entire map is under a roof), don't spawn a highmate
  - Very unlikely since you needed to get a bestower for the ceremony first, and the highmate at worst would attempt to spawn in that spot